### PR TITLE
remove custom includes

### DIFF
--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -1,3 +1,1 @@
-#include <inttypes.h>
-#include <stdbool.h>
 #include <FDP.h>


### PR DESCRIPTION
After a fix on icebox: https://github.com/thalium/icebox/commit/cbe8adb94d8deda3d8b9766afec0dbeae802a221